### PR TITLE
Safer regedit call

### DIFF
--- a/Drachenhorn.Desktop/UserSettings/SquirrelManager.cs
+++ b/Drachenhorn.Desktop/UserSettings/SquirrelManager.cs
@@ -199,7 +199,7 @@ namespace Drachenhorn.Desktop.UserSettings
                     File.WriteAllText(tempFile, reg);
 
                     // ReSharper disable once PossibleNullReferenceException
-                    Process.Start("regedit.exe", "/s " + tempFile).WaitForExit();
+                    Process.Start("regedit.exe", "/s \"" + tempFile + "\"").WaitForExit();
 
                     Application.Current.Shutdown();
                 }
@@ -264,7 +264,7 @@ namespace Drachenhorn.Desktop.UserSettings
                 File.WriteAllText(tempFile, reg);
 
                 // ReSharper disable once PossibleNullReferenceException
-                Process.Start("regedit.exe", "/s " + tempFile).WaitForExit();
+                Process.Start("regedit.exe", "/s \"" + tempFile + "\"").WaitForExit();
             }
         }
 


### PR DESCRIPTION
Hi, I used your code as a basis to create an app and was having problems with regedit where it would simply not create the registries.
After investigation I discovered it only happened when the user running application had spaces in his name, therefore the TEMP folder had spaces and it screwed up the command line for regedit.
Simply wrapping the file path in quotes fixed everything, so I would like to share it.
Thanks and awesome work mate 👍